### PR TITLE
avoid preview showing loading screen located in footer

### DIFF
--- a/.asciidoctorconfig
+++ b/.asciidoctorconfig
@@ -1,5 +1,7 @@
 :stylesdir: {asciidoctorconfigdir}/src/css
 :stylesheet: oncourse.css
 
-#:docinfodir: {asciidoctorconfigdir}/src
-#:docinfo: shared
+:docinfodir: {asciidoctorconfigdir}/src
+// for now only include the header and not the footer
+// as the footer contains a loading splash screen
+:docinfo: shared-head


### PR DESCRIPTION
When previewing the AsciiDoc contents in IntelliJ, the preview shows the loading image. 

This is due to change b501a833677bce64b68bfe830b05958f6477b88f that changed the loading image from JavaScript to pure HTML.

This is a workaround (maybe even a fix) for https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/567